### PR TITLE
Add publish docker image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,7 +26,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/arozos
           flavor: |
             latest=true            
       - name: Build and push Docker image

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+  # release:
+  #   types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the codebase
+        uses: actions/checkout@v4
+      - name: Login to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=true            
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./container
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "2"
 services:
   app:
+    image: ghcr.io/sysadmin74/arozos
     build: ./container
     volumes:
       - ./container/data/files:/arozos/files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   app:
     image: ghcr.io/sysadmin74/arozos


### PR DESCRIPTION
This PR adds a github workflow, that builds and publishes a ready to use docker image. 

You can see a sample run here:
https://github.com/TheZoker/ArozOS-Docker/actions/runs/9340095837/job/25705228863

A sample published image:
https://github.com/TheZoker/ArozOS-Docker/pkgs/container/arozos-docker

Here is the official documentation:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images